### PR TITLE
Add default CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Reviewers (and by extension approvers) will be the default owners for everything in the repo.
+# Unless a later match takes precedence, @reviewers will be requested for review when someone opens a pull request.
+*     @ros-tooling/reviewers


### PR DESCRIPTION
This will help auto-assign PR reviewers. This is the default state for all ros-tooling repos, it might be specialized beyond this for individual repos